### PR TITLE
enable lexical binding

### DIFF
--- a/helm-rage.el
+++ b/helm-rage.el
@@ -1,4 +1,4 @@
-;;; helm-rage.el --- Helm command for rage characters.
+;;; helm-rage.el --- Helm command for rage characters. -*- lexical-binding: t; -*-
 
 ;; Copyright © 2016 Patrick Haun
 


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

If any problems do arise, feel free to ping me and I will follow up this PR.
